### PR TITLE
kyoproのdevcontainerでファイルを作成したときにパーミッションの問題を解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 node_modules
+.cache
+.vscode-server
 
 # C++のビルドファイルを除外
 /kyopro/**/*.out
 
 # act実行時に使うトークンが書かれたファイルを除外
 /act.secrets
+

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "github.vscode-github-actions",
+    "GitHub.vscode-pull-request-github",
     "ms-azuretools.vscode-docker",
     "phind.phind",
     "ritwickdey.LiveServer",

--- a/kyopro/.devcontainer/devcontainer.json
+++ b/kyopro/.devcontainer/devcontainer.json
@@ -9,5 +9,6 @@
     }
   },
   "workspaceFolder": "/home/developer",
-  "initializeCommand": "echo 'Hello World!'" // @see https://github.com/microsoft/vscode-remote-release/issues/9302#issuecomment-1859139566
+  "initializeCommand": "echo 'Hello World!'", // @see https://github.com/microsoft/vscode-remote-release/issues/9302#issuecomment-1859139566
+  "updateRemoteUserUID": true // @see https://containers.dev/implementors/json_reference/
 }

--- a/kyopro/Dockerfile
+++ b/kyopro/Dockerfile
@@ -1,7 +1,10 @@
+# devcontainerのイメージのためのDockerfile
+
 FROM ubuntu:22.04
 
 ENV TZ=Asia/Tokyo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 
 # create env to compile c++
 RUN apt update && apt install sudo -y
@@ -17,13 +20,15 @@ RUN apt install python3.10 -y
 RUN ln -s /usr/bin/python3.10 /usr/bin/python
 RUN ln -s /usr/bin/python3.10 /usr/bin/python3
 
-# install git
-RUN sudo apt install git-all -y
-
 WORKDIR /home/developer/src
 
 # bashrcに設定を追加
 COPY ./.devcontainer/devcontainer.bashrc /root/.tmpBashrcToAdd
 RUN cat /root/.tmpBashrcToAdd >> /root/.bashrc
+
+# グループ・ユーザーを作成(gid、uidはdevcontainer.jsonのupdateRemoteUserUIDによってホスト側で使っているユーザーのuidとgidに上書きされる)
+RUN groupadd -g 1100 developer && \
+    useradd -m -s /bin/bash -u 1100 -g 1100 developer
+USER developer
 
 CMD ["bash"]


### PR DESCRIPTION
## What
- Dockerfileで適当なuidとgidでユーザーを作成
- devcontainer.jsonで上記で作成したユーザーのuidとgidをDockerホスト側で使っているユーザーのuidとgidで上書き(devcontainer.jsonのupdateRemoteUserUIDを使用)

## Appendix
- https://containers.dev/implementors/json_reference/
- https://zenn.dev/aidemy/articles/3b34214b9aabf4