### PR TITLE
kyoproのdevcontainerでbashrcの設定が反映されなくなっていた問題を修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,4 @@ services:
     volumes:
       - type: bind
         source: ./kyopro
-        target: /home/developer
+        target: /home/developer/kyopro

--- a/kyopro/Dockerfile
+++ b/kyopro/Dockerfile
@@ -20,15 +20,13 @@ RUN apt install python3.10 -y
 RUN ln -s /usr/bin/python3.10 /usr/bin/python
 RUN ln -s /usr/bin/python3.10 /usr/bin/python3
 
-WORKDIR /home/developer/src
-
-# bashrcに設定を追加
-COPY ./.devcontainer/devcontainer.bashrc /root/.tmpBashrcToAdd
-RUN cat /root/.tmpBashrcToAdd >> /root/.bashrc
-
 # グループ・ユーザーを作成(gid、uidはdevcontainer.jsonのupdateRemoteUserUIDによってホスト側で使っているユーザーのuidとgidに上書きされる)
 RUN groupadd -g 1100 developer && \
     useradd -m -s /bin/bash -u 1100 -g 1100 developer
+# bashrcに設定を追加
+COPY ./.devcontainer/devcontainer.bashrc /home/developer/.tmpBashrcToAdd
+RUN cat /home/developer/.tmpBashrcToAdd >> /home/developer/.bashrc
+
 USER developer
 
 CMD ["bash"]


### PR DESCRIPTION
- developerユーザーのホームディレクトリにマウントすると、image作成時に同ディレクトリに作成していた.bashrcが消されてしまうことが原因だった。
- Dockerホストからのマウント先をホームディレクトリから一段下のディレクトリにすることで解決した。